### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,38 +27,37 @@
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
-		"grunt": "~0.4.1",
-		"grunt-contrib-concat": "~0.3.0",
-		"grunt-contrib-uglify": "~0.2.5",
-		"grunt-contrib-jshint": "~0.7.0",
-		"grunt-angular-templates": "~0.3.6",
-		"grunt-contrib-less": "~0.8.1",
-		"grunt-contrib-cssmin": "~0.7.0",
-		"grunt-contrib-watch":"~0.5.3",
-		"grunt-focus": "~0.1.1"
+    "grunt": "~0.4.1",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-uglify": "~0.2.5",
+    "grunt-contrib-jshint": "~0.7.0",
+    "grunt-angular-templates": "~0.3.6",
+    "grunt-contrib-less": "~0.8.1",
+    "grunt-contrib-cssmin": "~0.7.0",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-focus": "~0.1.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",
     "buildfiles",
-	"grunt-buildfiles",
-	"template",
-	"build",
-	"files",
-	"assets",
-	"jshint",
-	"lint",
-	"concat",
-	"uglify",
-	"minify",
-	"css",
-	"less",
-	"html",
-	"javascript"
+    "grunt-buildfiles",
+    "template",
+    "build",
+    "files",
+    "assets",
+    "jshint",
+    "lint",
+    "concat",
+    "uglify",
+    "minify",
+    "css",
+    "less",
+    "html",
+    "javascript"
   ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
